### PR TITLE
Fix auto turn ai bug

### DIFF
--- a/src/ai.cpp
+++ b/src/ai.cpp
@@ -3,7 +3,6 @@
 bool AI::init()
 {
 	std::srand(std::time(nullptr));
-
 	return true;
 }
 
@@ -84,13 +83,15 @@ void AI::get_best_turning_direction(
 	// Don't want to modify the real game lanes
 	std::map<direction, Lane*> new_lanes = deep_copy_lanes(current_lanes);
 	std::vector<std::set<direction>> possible_moves = generate_moves(new_lanes);
+	int next_ply = current_ply + 1;
 	
 	for (std::vector<std::set<direction>>::iterator it = possible_moves.begin(); it != possible_moves.end(); it++)
 	{
 		apply_move_to_lanes(*it, new_lanes);
 		bool is_moving_active_lane = it->find(active_lane) != it->end();
+		int next_total_cars_turned = cars_turned + it->size();
 
-		get_best_turning_direction(active_lane, new_lanes, current_ply + 1, cars_turned + it->size(), is_moving_active_lane, bestPlayerOutcome);
+		get_best_turning_direction(active_lane, new_lanes, next_ply, next_total_cars_turned, is_moving_active_lane, bestPlayerOutcome);
 		for (auto current = new_lanes.begin(); current != new_lanes.end(); ++current) {
 			delete current->second;
 		}
@@ -281,7 +282,7 @@ direction AI::get_most_villainous_direction(direction active_lane, std::map<dire
 		int best_move_size = moves.begin()->size();
 
 		if (best_move_size < best_direction_score) {
-			best_direction = directions[i];
+			best_direction = current_direction;
 			best_direction_score = best_move_size;
 		}
 	}

--- a/src/ai.hpp
+++ b/src/ai.hpp
@@ -21,11 +21,11 @@ struct PlayerOutcome
 class AI
 {
 public:
-	const int MaxPly = 5;
+	static const int MaxPly = 3;
 
 	// Estimated time it takes for the player to execute a move.
 	// Used to determine if the player must move a specific lane due to a time constraint
-	const float EstimatedPlayerMoveTime = 400;
+	static const int EstimatedPlayerMoveTime = 400;
 
 	bool init();
 

--- a/src/lane.cpp
+++ b/src/lane.cpp
@@ -93,28 +93,24 @@ void Lane::add_car(carType type)
 				new_car.set_rotation(PI / 2);
 				new_car.set_original_rotation(PI / 2);
 				new_car.set_lane(direction::NORTH);
-				//new_car.set_desired_direction(direction::EAST);
 			}
 			else if (m_dir == direction::WEST) {
 				new_car.set_position({ -130.f,537.f });
 				new_car.set_lane(direction::WEST);
 				new_car.set_rotation(0);
 				new_car.set_original_rotation(0);
-				new_car.set_desired_direction(direction::EAST);
 			}
 			else if (m_dir == direction::EAST) {
 				new_car.set_position({ 1100.f,445.f });
 				new_car.set_rotation(PI);
 				new_car.set_original_rotation(PI);
 				new_car.set_lane(direction::EAST);
-				new_car.set_desired_direction(direction::WEST);
 			}
 			else if (m_dir == direction::SOUTH) {
 				new_car.set_position({ 550,1100.f });
 				new_car.set_rotation(3.0*PI / 2.0);
 				new_car.set_original_rotation(3.0*PI / 2.0);
 				new_car.set_lane(direction::SOUTH);
-				new_car.set_desired_direction(direction::WEST);
 			}
 			new_car.generate_desired_direction();
 			m_cars.emplace_back(new_car);

--- a/src/lane_manager.cpp
+++ b/src/lane_manager.cpp
@@ -155,7 +155,6 @@ bool LaneManager::intersection_collision_check() {
 }
 
 int LaneManager::mesh_collision_check(Car* attacker_car, Car* victim_car, vec2 impact_vertex) {
-	printf("tryna collide\n");
 
 	Car::Triangle victim_triangles[14];
 

--- a/src/lane_manager.hpp
+++ b/src/lane_manager.hpp
@@ -41,7 +41,7 @@ public:
 
 		bool lane_collision_check(Car& current_car, Car& front_car);
 
-		void lane_queue(Lane* lane, vec2 lane_intersection,float ms);
+		bool lane_queue(Lane* lane, vec2 lane_intersection,float ms);
 
 		// Will return true if any cars in the process of turning are colliding
 		bool intersection_collision_check();


### PR DESCRIPTION
This PR fixes the bug where the game would crash when the AI tried to determine villains after the lanes auto moved due to the timer expiring.

Note: Let me know if you experience slight slowness. Ply depth 5 works for me on Release but is a little slow on debug, so I put it down to ply depth 3.