### PR TITLE
Crash sound does not repeat anymore when stacked crashed cars

### DIFF
--- a/src/car.cpp
+++ b/src/car.cpp
@@ -838,7 +838,6 @@ bool Car::check_implicit(vec2 P1, vec2 P2, vec2 Ptest) {
 
 void Car::collided(int hit_triangle) {
 	if (!m_hit) {
-		Mix_PlayChannel(-1, m_crash, 0);
 		m_hit = true;
 		float speed_scale = m_max_speed;
 		float acc_scale = ACC;
@@ -850,6 +849,7 @@ void Car::collided(int hit_triangle) {
 }
 
 float Car::get_collision_spin(int hit_triangle) {
+	Mix_PlayChannel(-1, m_crash, 0);
 	switch(hit_triangle) {
 		case 1:
 		case 3:

--- a/src/car.cpp
+++ b/src/car.cpp
@@ -38,6 +38,12 @@ uint16_t indices[] = {
 
 bool Car::init(bool isVillain)
 {
+	//setting up audio for crash track
+	SDL_Init(SDL_INIT_AUDIO);
+	Mix_OpenAudio(44100, MIX_DEFAULT_FORMAT, 2, 2048);
+	m_crash = Mix_LoadWAV(audio_path("carCrash.wav"));
+	Mix_AllocateChannels(3);
+
 	// Load shared texture
 	if (!car_texture.is_valid())
 	{
@@ -832,6 +838,8 @@ bool Car::check_implicit(vec2 P1, vec2 P2, vec2 Ptest) {
 
 void Car::collided(int hit_triangle) {
 	if (!m_hit) {
+		Mix_VolumeChunk(m_crash, MIX_MAX_VOLUME / 2);
+		Mix_PlayChannel(-1, m_crash, 0);
 		m_hit = true;
 		float speed_scale = m_max_speed;
 		float acc_scale = ACC;

--- a/src/car.cpp
+++ b/src/car.cpp
@@ -42,7 +42,7 @@ bool Car::init(bool isVillain)
 	SDL_Init(SDL_INIT_AUDIO);
 	Mix_OpenAudio(44100, MIX_DEFAULT_FORMAT, 2, 2048);
 	m_crash = Mix_LoadWAV(audio_path("carCrash.wav"));
-	Mix_AllocateChannels(3);
+	Mix_VolumeChunk(m_crash, MIX_MAX_VOLUME / 2);
 
 	// Load shared texture
 	if (!car_texture.is_valid())
@@ -838,7 +838,6 @@ bool Car::check_implicit(vec2 P1, vec2 P2, vec2 Ptest) {
 
 void Car::collided(int hit_triangle) {
 	if (!m_hit) {
-		Mix_VolumeChunk(m_crash, MIX_MAX_VOLUME / 2);
 		Mix_PlayChannel(-1, m_crash, 0);
 		m_hit = true;
 		float speed_scale = m_max_speed;

--- a/src/car.hpp
+++ b/src/car.hpp
@@ -10,6 +10,10 @@
 #include <cmath>
 #include <stdexcept>
 
+#define SDL_MAIN_HANDLED
+#include <SDL/SDL.h>
+#include <SDL/SDL_mixer.h>
+
 using std::string;
 
 class Car : public Renderable
@@ -183,4 +187,5 @@ private:
 	bool m_at_intersection;
 	float car_tex_x0; //specifies near x offset of the indicated car texture
 	float m_spin_amount;
+	Mix_Chunk* m_crash;
 };

--- a/src/lane_manager.cpp
+++ b/src/lane_manager.cpp
@@ -5,11 +5,6 @@
 
 bool LaneManager::init(AI ai)
 {
-  SDL_Init(SDL_INIT_AUDIO);
-  Mix_OpenAudio(44100, MIX_DEFAULT_FORMAT, 2, 2048);
-  m_crash = Mix_LoadWAV(audio_path("carCrash.wav"));
-  Mix_AllocateChannels(3);
-  
   m_lanes[direction::NORTH] = new Lane(direction::NORTH, VillainSpawnProbability);
   m_lanes[direction::EAST] = new Lane(direction::EAST, VillainSpawnProbability);
   m_lanes[direction::SOUTH] = new Lane(direction::SOUTH, VillainSpawnProbability);
@@ -101,10 +96,6 @@ bool LaneManager::intersection_collision_check() {
 				}
 			}
 		}
-	}
-	if (collision_occurring) {
-		Mix_VolumeChunk(m_crash, MIX_MAX_VOLUME / 2);
-		Mix_PlayChannel(-1, m_crash, 0);
 	}
 	return collision_occurring;
 }

--- a/src/lane_manager.cpp
+++ b/src/lane_manager.cpp
@@ -242,7 +242,7 @@ LaneManager::collisionTuple LaneManager::mesh_collision_check(Car* attacker_car,
 			if (victim_car->check_mesh_collision(attacker_tri.a, victim_tri)
 				|| victim_car->check_mesh_collision(attacker_tri.b, victim_tri)
 				|| victim_car->check_mesh_collision(attacker_tri.c, victim_tri)) {
-					printf("triangle vic: %i, attack: %i hit\n", vic_counter, attack_counter);
+					//printf("triangle vic: %i, attack: %i hit\n", vic_counter, attack_counter);
 					//Sleep(1000);
 					collisionTriangles.victim_index = vic_counter;
 					collisionTriangles.attacker_index = attack_counter;

--- a/src/lane_manager.hpp
+++ b/src/lane_manager.hpp
@@ -8,9 +8,7 @@
 
 #include <map>
 #include <string>
-#define SDL_MAIN_HANDLED
-#include <SDL/SDL.h>
-#include <SDL/SDL_mixer.h>
+
 
 class LaneManager
 {
@@ -66,5 +64,5 @@ private:
 	std::map<direction, vec2> m_lane_coords;
 	unsigned int m_points;
 	
-	Mix_Chunk* m_crash;
+
 };

--- a/src/lane_manager.hpp
+++ b/src/lane_manager.hpp
@@ -63,4 +63,5 @@ private:
 	AI* m_ai;
 	std::map<direction, vec2> m_lane_coords;
 	unsigned int m_points;
+	float spawn_delay;
 };


### PR DESCRIPTION
booms once per car, even when cars end up on each other.

Should work for non-first cars once the collision bug has been fixed. @theochit could you try it with your patched branch?